### PR TITLE
Hotfix- lidar projection was previously done based on velodyne point …

### DIFF
--- a/tool/gen_kitti_dataset.py
+++ b/tool/gen_kitti_dataset.py
@@ -66,7 +66,7 @@ for in_idx in tqdm(range(len(train_lines))):
     gt_file, gt_calib, im_size, im_file, cams = read_file_data_new(train_lines[in_idx], data_path)
     # print('cams:', cams)
     camera_id = cams[0]
-    depth = generate_depth_map(gt_calib[0], gt_file[0], im_size[0], camera_id, False, True)
+    depth = generate_depth_map(gt_calib[0], gt_file[0], im_size[0], camera_id, False, False)
     print(depth)
     print(np.max(depth), np.min(depth))
 


### PR DESCRIPTION
There was an incorrect flag in original monodepth lidar projection which was kept there for reproducibility purposes. Using incorrect flag will calculate depth from lidar not the camera.
see github.com/mrharicot/monodepth/issues/166#issuecomment-399392115
